### PR TITLE
Update codeql-analysis.yml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
- Prevent rogue GitHub Actions by enforcing timeout of three minutes (most runs are sub-two minutes)